### PR TITLE
Add stripe client payment form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "kk-beauty",
       "version": "0.1.0",
       "dependencies": {
+        "@stripe/react-stripe-js": "^3.8.1",
+        "@stripe/stripe-js": "^7.7.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -3261,6 +3263,29 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-3.8.1.tgz",
+      "integrity": "sha512-BExESIwXDwZgUqFmWj046BGpsqK4vNaBCdcmRvagQzOovjO2aBAt8rofW47K1TJRnt3iTH5dciBdHJ7ZA958ng==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=1.44.1 <8.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.7.0.tgz",
+      "integrity": "sha512-SXuhqhuR5FXaYgKTXzZJeqtVA6JKb9IZWaGeEUxHHiOcFy2p51wccO72bYpXwoK4D5pzQOIYLTuAc7etxyMmwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
       }
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@stripe/react-stripe-js": "^3.8.1",
+    "@stripe/stripe-js": "^7.7.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
@@ -47,12 +49,12 @@
   },
   "devDependencies": {
     "@types/styled-components": "^5.1.34",
+    "autoprefixer": "^10.4.21",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.4.0",
+    "postcss": "^8.4.35",
     "prettier": "^3.5.3",
     "serve": "^14.2.4",
-    "tailwindcss": "^3.4.17",
-    "postcss": "^8.4.35",
-    "autoprefixer": "^10.4.21"
+    "tailwindcss": "^3.4.17"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { HashRouter as Router, Routes, Route } from 'react-router-dom';
 import Products from './pages/Products';
 import Cart from './pages/Cart';
 import ContactUs from './pages/ContactUs';
+import Checkout from './pages/Checkout';
 import { CartProvider } from './context/CartContext';
 
 const GlobalStyle = createGlobalStyle`
@@ -61,6 +62,7 @@ const App: React.FC = () => (
             <Route path="/products" element={<Products />} />
             <Route path="/newsletter" element={<NewsletterPage />} />
             <Route path="/cart" element={<Cart />} />
+            <Route path="/checkout" element={<Checkout />} />
             <Route path="/contact" element={<ContactUs />} />
           </Routes>
           <Footer />

--- a/src/components/CheckoutForm.tsx
+++ b/src/components/CheckoutForm.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { CardElement, useElements, useStripe } from '@stripe/react-stripe-js';
+
+const CheckoutForm: React.FC = () => {
+  const stripe = useStripe();
+  const elements = useElements();
+  const [error, setError] = useState<string | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!stripe || !elements) return;
+    const card = elements.getElement(CardElement);
+    if (!card) return;
+
+    const result = await stripe.createToken(card);
+    if (result.error) {
+      setError(result.error.message || 'Payment failed');
+      setToken(null);
+    } else if (result.token) {
+      setToken(result.token.id);
+      setError(null);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <CardElement options={{ hidePostalCode: true }} />
+      <button
+        type="submit"
+        disabled={!stripe}
+        style={{
+          padding: '0.5rem 1rem',
+          background: '#2563eb',
+          color: '#fff',
+          borderRadius: '4px',
+          border: 'none',
+        }}
+      >
+        Pay
+      </button>
+      {error && <div style={{ color: 'red' }}>{error}</div>}
+      {token && <div style={{ color: 'green' }}>Token: {token}</div>}
+    </form>
+  );
+};
+
+export default CheckoutForm;

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Elements } from '@stripe/react-stripe-js';
+import { loadStripe } from '@stripe/stripe-js';
+import CheckoutForm from '../components/CheckoutForm';
+
+const stripePromise = loadStripe('pk_test_12345');
+
+const Checkout: React.FC = () => (
+  <main style={{ marginTop: '6.5rem', minHeight: '60vh' }}>
+    <div
+      style={{
+        width: '75%',
+        maxWidth: '500px',
+        margin: '0 auto',
+        background: '#181818',
+        padding: '2rem',
+        borderRadius: '0.5rem',
+        color: '#fff',
+      }}
+    >
+      <h1
+        style={{
+          fontFamily: 'Georgia, serif',
+          fontSize: '2rem',
+          marginBottom: '1rem',
+          textAlign: 'center',
+        }}
+      >
+        Checkout
+      </h1>
+      <Elements stripe={stripePromise}>
+        <CheckoutForm />
+      </Elements>
+    </div>
+  </main>
+);
+
+export default Checkout;


### PR DESCRIPTION
## Summary
- install Stripe libraries
- add `CheckoutForm` with basic `CardElement`
- create `Checkout` page
- wire checkout route in app

## Testing
- `npm run lint`
- `npm run build`
- `npm test -- -w 1` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a9e449d608330a0c00dd7f62ee52b